### PR TITLE
[FIX] Print error message in crawl result

### DIFF
--- a/src/crawler.js
+++ b/src/crawler.js
@@ -197,7 +197,7 @@ Crawler.prototype.crawl = function(ipp, hops) {
     if (error) {
       // save error
       var err = {}
-      err[ipp] = error;
+      err[ipp] = error.message;
       self.errors.push(err);
     } else {
       // mark ipp as done (received response)
@@ -246,7 +246,7 @@ Crawler.prototype.crawlSelective = function(ipps) {
       if (error) {
         // save error
         var err = {}
-        err[ipp] = error;
+        err[ipp] = error.message;
         self.errors.push(err);
         //console.error(error);
       } else {


### PR DESCRIPTION
+r
The crawl result was storing an error object. `JSON.stringify` caused no error to appear. This is fixed by storing the error message string instead.
